### PR TITLE
Fix function name in documentation

### DIFF
--- a/source/os_specific/efi/osefixf.c
+++ b/source/os_specific/efi/osefixf.c
@@ -184,7 +184,7 @@ struct _ACPI_EFI_RUNTIME_SERVICES    *RT;
 
 /******************************************************************************
  *
- * FUNCTION:    AcpiEfiGetRsdpViaGuid
+ * FUNCTION:    AcpiEfiCompareGuid
  *
  * PARAMETERS:  Guid1               - GUID to compare
  *              Guid2               - GUID to compare


### PR DESCRIPTION
The function name in the documentation of AcpiEfiCompareGuid was referring to the wrong function.